### PR TITLE
Hotfix 2023 07 31 (#564)

### DIFF
--- a/classes/OccurrenceTaxaManager.php
+++ b/classes/OccurrenceTaxaManager.php
@@ -376,7 +376,7 @@ class OccurrenceTaxaManager {
 		$str = trim($str,' ,;');
 		if($str == '%') $str = '';
 		$str = strip_tags($str);
-		$str = filter_var($str, FILTER_SANITIZE_STRING);
+		$str = htmlspecialchars($str, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML401);
 		return $str;
 	}
 

--- a/classes/TaxonSearchSupport.php
+++ b/classes/TaxonSearchSupport.php
@@ -99,12 +99,13 @@ class TaxonSearchSupport{
 	//Setters and getters
 	public function setQueryString($queryString){
 		//$queryString = $this->cleanInStr($queryString);
-		$queryString = preg_replace('/[\'"+\=@$%]+/i', '', $queryString);
+		$queryString = preg_replace('/[\+\=@$%]+/i', '', $queryString);
 		if(strpos($queryString, ' ')){
+			$queryString = str_ireplace(array('"', "'"), '_', $queryString);
 			$queryString = preg_replace('/\s{1}x{1}$/i', ' _', $queryString);
 			$queryString = preg_replace('/\s{1}x{1}\s{1}/i', ' _ ', $queryString);
-			$queryString = str_ireplace(' x', ' _', $queryString);
 			$queryString = str_ireplace(' x ', ' _ ', $queryString);
+			$queryString = str_ireplace(' x', ' _', $queryString);
 		}
 		$this->queryString = $queryString;
 	}

--- a/classes/TaxonomyHarvester.php
+++ b/classes/TaxonomyHarvester.php
@@ -330,6 +330,9 @@ class TaxonomyHarvester extends Manager{
 		elseif(isset($nodeArr['name']['scientificName'])) $taxonArr['sciname'] = $nodeArr['name']['scientificName'];
 		if(isset($nodeArr['rank'])) $taxonArr['taxonRank'] = $nodeArr['rank'];
 		elseif(isset($nodeArr['name']['rank'])) $taxonArr['taxonRank'] = $nodeArr['name']['rank'];
+		if($taxonArr['taxonRank'] == 'Unranked'){
+			if(isset($nodeArr['accepted_name']['rank'])) $taxonArr['taxonRank'] = $nodeArr['accepted_name']['rank'];
+		}
 		if(isset($nodeArr['genus'])) $taxonArr['unitname1'] = $nodeArr['genus'];
 		elseif(isset($nodeArr['name']['genus'])) $taxonArr['unitname1'] = $nodeArr['name']['genus'];
 		elseif(isset($nodeArr['name']['uninomial'])) $taxonArr['unitname1'] = $nodeArr['name']['uninomial'];

--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -435,13 +435,13 @@ class TaxonomyUpload{
 
 		$sql = 'UPDATE uploadtaxa u INNER JOIN uploadtaxa u2 ON u.sourceParentId = u2.sourceId '.
 			'SET u.parentstr = u2.sciname '.
-			'WHERE (u.parentstr IS NULL) AND (u.sourceParentId IS NOT NULL) AND (u2.sourceId IS NOT NULL)';
+			'WHERE (u.parentstr IS NULL)';
 		if(!$this->conn->query($sql)){
 			$this->outputMsg('ERROR: '.$this->conn->error,1);
 		}
 		$sql = 'UPDATE uploadtaxa u INNER JOIN uploadtaxa u2 ON u.sourceAcceptedId = u2.sourceId '.
 			'SET u.acceptedstr = u2.sciname '.
-			'WHERE (u.acceptedstr IS NULL) AND (u.sourceAcceptedId IS NOT NULL) AND (u2.sourceId IS NOT NULL)';
+			'WHERE (u.acceptedstr IS NULL)';
 		if(!$this->conn->query($sql)){
 			$this->outputMsg('ERROR: '.$this->conn->error,1);
 		}
@@ -452,7 +452,8 @@ class TaxonomyUpload{
 
 		//Link names already in theusaurus
 		$this->outputMsg('Linking names already in thesaurus... ');
-		$sql = 'UPDATE uploadtaxa u INNER JOIN taxa t ON u.sciname = t.sciname SET u.tid = t.tid WHERE (u.tid IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'") ';
+		$sql = 'UPDATE uploadtaxa u INNER JOIN taxa t ON u.sciname = t.sciname SET u.tid = t.tid
+			WHERE (u.tid IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'" OR t.sciname = "'.$this->kingdomName.'" OR t.rankid < 10) ';
 		if(!$this->conn->query($sql)){
 			$this->outputMsg('ERROR: '.$this->conn->error,1);
 		}
@@ -465,7 +466,7 @@ class TaxonomyUpload{
 		}
 		$sql = 'UPDATE uploadtaxa u INNER JOIN taxa t ON u.acceptedstr = t.sciname '.
 			'SET u.tidaccepted = t.tid '.
-			'WHERE (u.tidaccepted IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'")';
+			'WHERE (u.tidaccepted IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'" OR t.sciname = "'.$this->kingdomName.'" OR t.rankid < 10)';
 		if(!$this->conn->query($sql)){
 			$this->outputMsg('ERROR: '.$this->conn->error,1);
 		}
@@ -570,7 +571,9 @@ class TaxonomyUpload{
 			$this->outputMsg('ERROR: '.$this->conn->error,1);
 		}
 
-		$sql = 'UPDATE uploadtaxa up INNER JOIN taxa t ON up.parentstr = t.sciname SET parenttid = t.tid WHERE (parenttid IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'")';
+		$sql = 'UPDATE uploadtaxa up INNER JOIN taxa t ON up.parentstr = t.sciname
+			SET parenttid = t.tid
+			WHERE (parenttid IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'" OR t.sciname = "'.$this->kingdomName.'" OR t.rankid < 10)';
 		if(!$this->conn->query($sql)){
 			$this->outputMsg('ERROR: '.$this->conn->error,1);
 		}
@@ -584,7 +587,7 @@ class TaxonomyUpload{
 		$this->conn->query($sql);
 		$sql = 'UPDATE uploadtaxa up INNER JOIN taxa t ON up.parentstr = t.sciname '.
 			'SET up.parenttid = t.tid '.
-			'WHERE (up.parenttid IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'")';
+			'WHERE (up.parenttid IS NULL) AND (t.kingdomname = "'.$this->kingdomName.'" OR t.sciname = "'.$this->kingdomName.'" OR t.rankid < 10)';
 		$this->conn->query($sql);
 
 		//Load into uploadtaxa parents of species not yet in taxa table
@@ -595,7 +598,7 @@ class TaxonomyUpload{
 		$this->conn->query($sql);
 		$sql = 'UPDATE uploadtaxa up LEFT JOIN taxa t ON up.parentstr = t.sciname '.
 			'SET up.parenttid = t.tid '.
-			'WHERE ISNULL(up.parenttid) AND (t.kingdomname = "'.$this->kingdomName.'")';
+			'WHERE ISNULL(up.parenttid) AND (t.kingdomname = "'.$this->kingdomName.'" OR t.sciname = "'.$this->kingdomName.'" OR t.rankid < 10)';
 		$this->conn->query($sql);
 
 		//Set acceptance to 0 where sciname <> acceptedstr

--- a/classes/TaxonomyUtilities.php
+++ b/classes/TaxonomyUtilities.php
@@ -46,8 +46,13 @@ class TaxonomyUtilities {
 			$okToCloseConn = true;
 			if($conn !== null) $okToCloseConn = false;
 			if(count($sciNameArr)){
-				if(strtolower($sciNameArr[0]) == 'x' || $sciNameArr[0] == '×' || mb_ord($sciNameArr[0]) == 215){
+				if(strtolower($sciNameArr[0]) == 'x' || $sciNameArr[0] == '×'){
 					$retArr['unitind1'] = array_shift($sciNameArr);
+				}
+				elseif(mb_ord($sciNameArr[0]) == 215){
+					$retArr['unitind1'] = '×';
+					$unitStr = substr(array_shift($sciNameArr), 2);
+					if($unitStr) array_unshift($sciNameArr, $unitStr);
 				}
 				elseif($sciNameArr[0] == '†' || mb_ord($sciNameArr[0]) == 8224){
 					$retArr['unitind1'] = array_shift($sciNameArr);
@@ -59,10 +64,15 @@ class TaxonomyUtilities {
 				//Genus
 				$retArr['unitname1'] = ucfirst(strtolower(array_shift($sciNameArr)));
 				if(count($sciNameArr)){
-					if(strtolower($sciNameArr[0]) == 'x' || mb_ord($sciNameArr[0]) == 215){
-						//Species level hybrid
+					if(strtolower($sciNameArr[0]) == 'x' || $sciNameArr[0] == '×'){
 						$retArr['unitind2'] = array_shift($sciNameArr);
 						$retArr['unitname2'] = array_shift($sciNameArr);
+					}
+					elseif(mb_ord($sciNameArr[0]) == 215){
+						$retArr['unitind2'] = '×';
+						$unitStr = substr(array_shift($sciNameArr), 2);
+						if($unitStr) $retArr['unitname2'] = $unitStr;
+						else $retArr['unitname2'] = array_shift($sciNameArr);
 					}
 					elseif(strpos($sciNameArr[0],'.') !== false){
 						//It is assumed that Author has been reached, thus stop process

--- a/collections/editor/dupesearch.php
+++ b/collections/editor/dupesearch.php
@@ -74,7 +74,7 @@ if(!$IS_ADMIN){
 						//Matching event, thus limit output
 						unset($tempOcc['family']);
 						unset($tempOcc['sciname']);
-						unset($tempOcc['tid']);
+						unset($tempOcc['tidinterpreted']);
 						unset($tempOcc['scientificnameauthorship']);
 						unset($tempOcc['taxonremarks']);
 						unset($tempOcc['identifiedby']);
@@ -98,12 +98,11 @@ if(!$IS_ADMIN){
 				var openerForm = opener.document.fullform;
 				if(document.getElementById("linkdupe-"+occId).checked == true){
 					openerForm.linkdupe.value = occId;
-
 				}
 				for(var k in tArr){
 					try{
 						var elem = openerForm.elements[k];
-						if(elem.disabled == false && elem.type != 'hidden' && (appendMode == false || elem.value == "")){
+						if(elem.disabled == false && (elem.type != 'hidden' || k == "tidinterpreted") && (appendMode == false || elem.value == "")){
 							elem.value = tArr[k];
 							elem.style.backgroundColor = "lightblue";
 							if(k != "tid") opener.fieldChanged(k);

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -515,7 +515,7 @@ else{
 	<script src="../../js/symb/collections.coordinateValidation.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/wktpolygontools.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/collections.georef.js?ver=2" type="text/javascript"></script>
-	<script src="../../js/symb/collections.editor.main.js?ver=3" type="text/javascript"></script>
+	<script src="../../js/symb/collections.editor.main.js?ver=4" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.tools.js?ver=4" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.imgtools.js?ver=3" type="text/javascript"></script>
 	<script src="../../js/jquery.imagetool-1.7.js?ver=140310" type="text/javascript"></script>

--- a/collections/map/index.php
+++ b/collections/map/index.php
@@ -442,7 +442,7 @@ if(isset($ACTIVATE_GEOLOCATION) && $ACTIVATE_GEOLOCATION == 1) $activateGeolocat
 			buildCollKey();
 			buildTaxaKey();
 			jscolor.init();
-			if(pointBounds){
+			if(!pointBounds.isEmpty){
 				map.fitBounds(pointBounds);
 				map.panToBounds(pointBounds);
 			}

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -2,7 +2,7 @@
 header('X-Frame-Options: DENY');
 header('Cache-control: private'); // IE 6 FIX
 date_default_timezone_set('America/Phoenix');
-$CODE_VERSION = '3.0.11';
+$CODE_VERSION = '3.0.12';
 
 if(!isset($CLIENT_ROOT) && isset($clientRoot)) $CLIENT_ROOT = $clientRoot;
 if(substr($CLIENT_ROOT,-1) == '/') $CLIENT_ROOT = substr($CLIENT_ROOT,0,strlen($CLIENT_ROOT)-1);

--- a/content/lang/glossary/index.en.php
+++ b/content/lang/glossary/index.en.php
@@ -7,8 +7,6 @@ Language: English
 
 include_once($SERVER_ROOT.'/content/lang/glossary/addterm.en.php');
 
-$LANG['PLEASE_REFINE'] = 'Please select a language and taxonomic group to see term list.';
-$LANG['PLEASE_TO_DWNLD'] = 'Please select a primary language and taxonomic group to download.';
 $LANG['PLEASE_TRANSL'] = 'Please select a maximum of three translations for the Translation Table. Please be sure to not select the primary language.';
 $LANG['PLEASE_ONE'] = 'Please select at least one translation for the Translation Table. Please be sure to not select the primary language.';
 $LANG['HOME'] = 'Home';
@@ -26,9 +24,12 @@ $LANG['LANG'] = 'Language';
 $LANG['SEARCH_TERM'] = 'Search Term';
 $LANG['SEARCH_DEF'] = 'Search within definitions';
 $LANG['SEARCH_TERMS'] = 'Search/Browse Terms';
-$LANG['NO_GLOSS'] = 'A glossary has not yet been established for this portal';
-$LANG['DISP_SRC'] = '(Display Sources)';
-$LANG['ADD_SRC'] = '(Add Sources)';
+$LANG['TERMS'] = 'Terms';
+$LANG['FOR'] = 'for';
+$LANG['IN'] = 'in';
+$LANG['KEYWORD'] = 'with keyword ';
+$LANG['DISP_SRC'] = 'Display Sources';
+$LANG['ADD_SRC'] = 'Add Sources';
 $LANG['TAX_CONTR'] = 'Contributors for Taxonomic Group';
 $LANG['TERM_CONTR'] = 'Terms and Definitions contributed by';
 $LANG['IMG_CONTR'] = 'Images contributed by';

--- a/content/lang/glossary/index.es.php
+++ b/content/lang/glossary/index.es.php
@@ -5,10 +5,8 @@ Language: Español (Spanish)
 ------------------
 */
 
-include_once($SERVER_ROOT.'/content/lang/glossary/addterm.en.php');
+include_once($SERVER_ROOT.'/content/lang/glossary/addterm.es.php');
 
-$LANG['PLEASE_REFINE'] = 'Por favor seleccione el idioma y grupo taxonómico para ver el listado de términos.';
-$LANG['PLEASE_TO_DWNLD'] = 'Por favor seleccione un idioma primario y un grupo taxonómico para descargar.';
 $LANG['PLEASE_TRANSL'] = 'Por favor seleccione un máximo de traducciones para la Tabla de Traducciones. Por favor asegúrese de no seleccionar el idioma primario.';
 $LANG['PLEASE_ONE'] = 'Por favor seleccione al menos una traducción para la Tabla de Traducciones. Por favor asegúrese de no seleccionar el idioma primario.';
 $LANG['HOME'] = 'Inicio';
@@ -26,9 +24,12 @@ $LANG['LANG'] = 'Idioma';
 $LANG['SEARCH_TERM'] = 'Término de Búsqueda';
 $LANG['SEARCH_DEF'] = 'Buscar entre las definiciones';
 $LANG['SEARCH_TERMS'] = 'Buscar/Explorar Términos';
-$LANG['NO_GLOSS'] = 'Un glosario aún no ha sido establecido para este portal';
-$LANG['DISP_SRC'] = '(Desplegar Fuentes)';
-$LANG['ADD_SRC'] = '(Añadir Fuentes)';
+$LANG['TERMS'] = 'Términos';
+$LANG['FOR'] = 'para';
+$LANG['IN'] = 'en';
+$LANG['KEYWORD'] = 'con palabra clave';
+$LANG['DISP_SRC'] = 'Desplegar Fuentes';
+$LANG['ADD_SRC'] = 'Añadir Fuentes';
 $LANG['TAX_CONTR'] = 'Contribuyentes para Grupo Taxonómico';
 $LANG['TERM_CONTR'] = 'Términos y Definiciones contribuídas por';
 $LANG['IMG_CONTR'] = 'Imágenes contribuídas por';

--- a/content/lang/glossary/individual.es.php
+++ b/content/lang/glossary/individual.es.php
@@ -5,7 +5,7 @@ Language: Español (Spanish)
 ------------------
 */
 
-include_once($SERVER_ROOT.'/content/lang/glossary/index.en.php');
+include_once($SERVER_ROOT.'/content/lang/glossary/index.es.php');
 
 $LANG['GLOSS_TERM_INFO'] = 'Información de Términos del Glosario';
 $LANG['LOADING'] = 'Descargando';

--- a/content/lang/glossary/sources.es.php
+++ b/content/lang/glossary/sources.es.php
@@ -5,7 +5,7 @@ Language: Español (Spanish)
 ------------------
 */
 
-include_once($SERVER_ROOT.'/content/lang/glossary/index.en.php');
+include_once($SERVER_ROOT.'/content/lang/glossary/index.es.php');
 
 $LANG['G_SOURCES'] = 'Manejo de Fuentes del Glosario';
 $LANG['MAIN_G'] = 'Glosario Principal';

--- a/content/lang/glossary/termdetails.es.php
+++ b/content/lang/glossary/termdetails.es.php
@@ -5,7 +5,7 @@ Language: Español (Spanish)
 ------------------
 */
 
-include_once($SERVER_ROOT.'/content/lang/glossary/addterm.en.php');
+include_once($SERVER_ROOT.'/content/lang/glossary/addterm.es.php');
 
 $LANG['G_MGMNT'] = 'Administración de Glosario';
 $LANG['LOAD'] = 'Cargando';

--- a/glossary/index.php
+++ b/glossary/index.php
@@ -3,7 +3,7 @@ include_once('../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/GlossaryManager.php');
 if($LANG_TAG == 'en' || !file_exists($SERVER_ROOT.'/content/lang/glossary/index.'.$LANG_TAG.'.php')) include_once($SERVER_ROOT.'/content/lang/glossary/index.en.php');
 else include_once($SERVER_ROOT.'/content/lang/glossary/index.'.$LANG_TAG.'.php');
-header("Content-Type: text/html; charset=".$CHARSET);
+header('Content-Type: text/html; charset=' . $CHARSET);
 
 $glossId = array_key_exists('glossid',$_REQUEST)?$_REQUEST['glossid']:0;
 $language = array_key_exists('searchlanguage',$_REQUEST)?$_REQUEST['searchlanguage']:'';
@@ -15,8 +15,8 @@ $formSubmit = array_key_exists('formsubmit',$_POST)?$_POST['formsubmit']:'';
 //Sanitation
 if(!is_numeric($glossId)) $glossId = 0;
 if(!is_numeric($tid)) $tid = 0;
-$language = filter_var($language,FILTER_SANITIZE_STRING);
-$searchTerm = filter_var($searchTerm,FILTER_SANITIZE_STRING);
+$language = htmlspecialchars($language, HTML_SPECIAL_CHARS_FLAGS);
+$searchTerm = htmlspecialchars($searchTerm, HTML_SPECIAL_CHARS_FLAGS);
 if(!is_numeric($deepSearch)) $relatedLanguage = 0;
 
 if(!$language) $language = $DEFAULT_LANG;
@@ -49,7 +49,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 ?>
 <html>
 <head>
-	<title><?php echo $DEFAULT_TITLE.' '.(isset($LANG['GLOSSARY'])?$LANG['GLOSSARY']:'Glossary'); ?></title>
+	<title><?php echo $DEFAULT_TITLE.' '.$LANG['GLOSSARY']; ?></title>
 	<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
 	include_once($SERVER_ROOT.'/includes/head.php');
@@ -83,26 +83,12 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 			}
 		}
 
-		function verifySearchForm(f){
-			if(!f.searchlanguage.value){
-				alert("<?php echo (isset($LANG['PLEASE_REFINE'])?$LANG['PLEASE_REFINE']:'Please select a language and taxonomic group to see term list.'); ?>");
-				return false;
-			}
-			return true;
-		}
-
 		function verifyDownloadForm(f){
 			var searchForm = document.searchform;
 			f.searchlanguage.value = searchForm.searchlanguage.value;
 			f.searchtaxa.value = searchForm.searchtaxa.value;
 			f.searchterm.value = searchForm.searchterm.value;
-			f.deepsearch.value = searchForm.deepsearch.value;
-			var language = f.searchlanguage.value;
-			var taxon = f.searchtaxa.value;
-			if(!language || !taxon){
-				alert("<?php echo (isset($LANG['PLEASE_TO_DWNLD'])?$LANG['PLEASE_TO_DWNLD']:'Please select a primary language and taxonomic group to download.'); ?>");
-				return false;
-			}
+			if(searchForm.deepsearch.checked) f.deepsearch.value = 1;
 
 			var downloadtype = f.exporttype.value;
 			if(downloadtype == 'translation'){
@@ -116,11 +102,11 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 					}
 				}
 				if(numTranslations > 3){
-					alert("<?php echo (isset($LANG['PLEASE_TRANSL'])?$LANG['PLEASE_TRANSL']:'Please select a maximum of three translations for the Translation Table. Please be sure to not select the primary language.'); ?>");
+					alert("<?php echo $LANG['PLEASE_TRANSL']; ?>");
 					return false;
 				}
 				if(numTranslations === 0){
-					alert("<?php echo (isset($LANG['PLEASE_ONE'])?$LANG['PLEASE_ONE']:'Please select at least one translation for the Translation Table. Please be sure to not select the primary language.'); ?>");
+					alert("<?php echo $LANG['PLEASE_ONE']; ?>");
 					return false;
 				}
 			}
@@ -145,28 +131,13 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 </head>
 <body>
 	<?php
-	$displayLeftMenu = (isset($glossary_indexMenu)?$glossary_indexMenu:false);
+	$displayLeftMenu = false;
 	include($SERVER_ROOT.'/includes/header.php');
-	if(isset($glossary_indexCrumbs)){
-		if($glossary_indexCrumbs){
-			?>
-			<div class='navpath'>
-				<a href='../index.php'><?php echo (isset($LANG['HOME'])?$LANG['HOME']:'Home'); ?></a> &gt;&gt;
-				<?php echo $glossary_indexCrumbs; ?>
-				<a href='index.php'> <b><?php echo (isset($LANG['GLOSSARY'])?$LANG['GLOSSARY']:'Glossary'); ?></b></a>
-			</div>
-			<?php
-		}
-	}
-	else{
-		?>
-		<div class='navpath'>
-			<a href='../index.php'><?php echo (isset($LANG['HOME'])?$LANG['HOME']:'Home'); ?></a> &gt;&gt;
-			<a href='index.php'> <b><?php echo (isset($LANG['GLOSSARY'])?$LANG['GLOSSARY']:'Glossary'); ?></b></a>
-		</div>
-		<?php
-	}
 	?>
+	<div class='navpath'>
+		<a href='../index.php'><?php echo (isset($LANG['HOME'])?$LANG['HOME']:'Home'); ?></a> &gt;&gt;
+		<a href='index.php'> <b><?php echo (isset($LANG['GLOSSARY'])?$LANG['GLOSSARY']:'Glossary'); ?></b></a>
+	</div>
 	<!-- This is inner text! -->
 	<div id="innertext">
 		<?php
@@ -188,14 +159,14 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 			echo '<div id="glossaryDescriptionDiv">'.$GLOSSARY_DESCRIPTION.'</div><div style="clear:both;"></div>';
 		}
 		?>
-		<div style="float:right;width:360px;position:relative;">
-			<div style="float:right;position:relative">
+		<div style="float:right;width:360px;">
+			<div style="float:right;">
 				<?php
 				if($isEditor){
 					?>
 					<div>
 						<a href="#" onclick="openNewTermPopup();">
-							<?php echo (isset($LANG['ADD_TERM'])?$LANG['ADD_TERM']:'Add New Term'); ?>
+							<?php echo $LANG['ADD_TERM']; ?>
 						</a>
 					</div>
 					<div>
@@ -212,7 +183,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 					</a>
 				</div>
 			</div>
-			<div id="downloadoptionsdiv" style="display:none;clear:both;position:absolute;right:0px;margin-top:45px;background-color:white;">
+			<div id="downloadoptionsdiv" style="display:none;clear:both;float:right;margin-top:15px;background-color:white;">
 				<form name="downloadform" action="glossdocexport.php" method="post" onsubmit="return verifyDownloadForm(this);">
 					<fieldset style="padding:8px">
 						<legend><b><?php echo (isset($LANG['DOWN_OP'])?$LANG['DOWN_OP']:'Download Options'); ?></b></legend>
@@ -253,105 +224,84 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 						else{
 							?>
 							<div style="margin-left:5px;">
-								<input name="exporttype" type="hidden" value="singlelanguage" />
+								<input name="exporttype" type="hidden" value="0" />
 								<input name="images" type="checkbox" value="images" /> <?php echo (isset($LANG['INCL_IMG'])?$LANG['INCL_IMG']:'Include Images'); ?>
 							</div>
 							<?php
 						}
 						?>
 						<div style="clear:both;padding:15px">
-							<input name="searchlanguage" type="hidden" value="" />
-							<input name="searchtaxa" type="hidden" value="" />
-							<input name="searchterm" type="hidden" value="" />
-							<input name="deepsearch" type="hidden" value="" />
+							<input name="searchlanguage" type="hidden" value="<?php echo $language; ?>" />
+							<input name="searchtaxa" type="hidden" value="<?php echo $tid; ?>" />
+							<input name="searchterm" type="hidden" value="<?php echo $searchTerm; ?>" />
+							<input name="deepsearch" type="hidden" value="<?php echo $deepSearch; ?>" />
 							<button name="formsubmit" type="submit" value="Download"><?php echo (isset($LANG['DOWNLOAD'])?$LANG['DOWNLOAD']:'Download'); ?></button>
 						</div>
 					</fieldset>
 				</form>
 			</div>
 		</div>
-		<?php
-		if($langArr){
-			?>
-			<h2><?php echo (isset($LANG['SEARCH_GL'])?$LANG['SEARCH_GL']:'Search/Browse Glossary'); ?></h2>
-			<div style="float:left;">
-				<form id="searchform" name="searchform" action="index.php" method="post" onsubmit="return verifySearchForm(this);">
-					<div style="height:25px;">
-						<?php
-						if(count($taxaArr) > 1){
-							?>
-							<div style="float:left;">
-								<b><?php echo (isset($LANG['TAX_GROUP'])?$LANG['TAX_GROUP']:'Taxonomic Group'); ?>:</b>
-								<select id="searchtaxa" name="searchtaxa" style="margin-top:2px;width:300px;" onchange="resetLanguageSelect(this.form)">
-									<option value=""><?php echo (isset($LANG['ALL_GROUPS'])?$LANG['ALL_GROUPS']:'Show terms for all groups'); ?></option>
-									<?php
-									foreach($taxaArr as $k => $v){
-										echo '<option value="'.$k.'" '.($k==$tid?'SELECTED':'').'>'.$v.'</option>';
-									}
-									?>
-								</select>
-							</div>
-							<?php
-						}
-						else{
-							echo '<input name="searchtaxa" type="hidden" value="'.key($taxaArr).'" />';
-						}
-						if(count($langArr) > 1){
-							?>
-							<div style="float:left;margin-left:10px;">
-								<b><?php echo (isset($LANG['LANG'])?$LANG['LANG']:'Language'); ?>:</b>
-								<select id="searchlanguage" name="searchlanguage" style="margin-top:2px;" onchange="">
-									<?php
-									foreach($langArr as $k => $v){
-										echo '<option value="'.$v.'" '.($v==$language||$k==$language?'SELECTED':'').'>'.$v.'</option>';
-									}
-									?>
-								</select>
-							</div>
-							<?php
-						}
-						else{
-							echo '<input name="searchlanguage" type="hidden" value="'.reset($langArr).'" />';
-						}
+		<h2><?php echo (isset($LANG['SEARCH_GL'])?$LANG['SEARCH_GL']:'Search/Browse Glossary'); ?></h2>
+		<div style="float:left;">
+			<form id="searchform" name="searchform" action="index.php" method="post" onsubmit="return verifySearchForm(this);">
+				<div style="height:25px;">
+					<?php
+					if($taxaArr){
 						?>
-					</div>
-					<div style="clear:both;">
-						<b><?php echo (isset($LANG['SEARCH_TERM'])?$LANG['SEARCH_TERM']:'Search Term'); ?>:</b>
-						<input type="text" autocomplete="off" name="searchterm" size="25" value="<?php echo $searchTerm; ?>" />
-					</div>
-					<div style="margin-left:40px">
-						<input name="deepsearch" type="checkbox" value="1" <?php echo $deepSearch?'checked':''; ?> />
-						<b><?php echo (isset($LANG['SEARCH_DEF'])?$LANG['SEARCH_DEF']:'Search within definitions'); ?></b>
-					</div>
-					<div style="margin:20px">
-						<button name="formsubmit" type="submit" value="Search Terms"><?php echo (isset($LANG['SEARCH_TERMS'])?$LANG['SEARCH_TERMS']:'Search/Browse Terms'); ?></button>
-					</div>
-				</form>
-			</div>
-			<?php
-		}
-		else{
-			echo '<div style="40px 20px"><h2>'.(isset($LANG['NO_GLOSS'])?$LANG['NO_GLOSS']:'A glossary has not yet been established for this portal').'</h2></div>';
-		}
-		?>
-		<div>
-			<div style="min-height:200px;clear:both">
-				<?php
-				if(!$formSubmit){
-					reset($taxaArr);
-					if(!$tid){
-						$tid = key($taxaArr);
-						$taxonName = $taxaArr[$tid];
+						<div style="float:left;">
+							<b><?php echo (isset($LANG['TAX_GROUP'])?$LANG['TAX_GROUP']:'Taxonomic Group'); ?>:</b>
+							<select id="searchtaxa" name="searchtaxa" style="margin-top:2px;width:300px;" onchange="resetLanguageSelect(this.form)">
+								<option value=""><?php echo (isset($LANG['ALL_GROUPS'])?$LANG['ALL_GROUPS']:'Show terms for all groups'); ?></option>
+								<?php
+								foreach($taxaArr as $k => $v){
+									echo '<option value="'.$k.'" '.($k==$tid?'SELECTED':'').'>'.$v.'</option>';
+								}
+								?>
+							</select>
+						</div>
+						<?php
 					}
-					if(!$language) $language = reset($langArr);
-				}
-				$termList = $glosManager->getTermSearch($searchTerm,$language,$tid,$deepSearch);
+					if(count($langArr) > 1){
+						?>
+						<div style="float:left;margin-left:10px;">
+							<b><?php echo (isset($LANG['LANG'])?$LANG['LANG']:'Language'); ?>:</b>
+							<select id="searchlanguage" name="searchlanguage" style="margin-top:2px;" onchange="">
+								<?php
+								foreach($langArr as $k => $v){
+									echo '<option value="'.$v.'" '.($v==$language||$k==$language?'SELECTED':'').'>'.$v.'</option>';
+								}
+								?>
+							</select>
+						</div>
+						<?php
+					}
+					?>
+				</div>
+				<div style="clear:both;">
+					<b><?php echo (isset($LANG['SEARCH_TERM'])?$LANG['SEARCH_TERM']:'Search Term'); ?>:</b>
+					<input type="text" autocomplete="off" name="searchterm" size="25" value="<?php echo $searchTerm; ?>" />
+				</div>
+				<div style="margin-left:40px">
+					<input name="deepsearch" type="checkbox" value="1" <?php echo $deepSearch?'checked':''; ?> />
+					<b><?php echo (isset($LANG['SEARCH_DEF'])?$LANG['SEARCH_DEF']:'Search within definitions'); ?></b>
+				</div>
+				<div style="margin:20px">
+					<button name="formsubmit" type="submit" value="Search Terms"><?php echo (isset($LANG['SEARCH_TERMS'])?$LANG['SEARCH_TERMS']:'Search/Browse Terms'); ?></button>
+				</div>
+			</form>
+		</div>
+		<div>
+			<div style="min-height:200px;clear:left">
+				<?php
+				$termList = $glosManager->getTermSearch($searchTerm, $language, $tid, $deepSearch);
 				if($termList){
-					$title = ($taxonName?$taxonName.' terms ':'Terms ').($language?' in '.$language:'');
-					if($searchTerm) $title .= ' and with a keyword of '.$searchTerm;
 					?>
 					<div>
 						<?php
+						$title = $LANG['TERMS'];
+						if($taxonName) $title .= ' '.$LANG['FOR'].' '.$taxonName;
+						if($language) $title .= ' '.$LANG['IN'].' '.$language;
+						if($searchTerm) $title .= ' '.$LANG['KEYWORD'].' &quot;'.$searchTerm.'&quot;';
 						echo '<div style="float:left;font-weight:bold;font-size:120%;">'.$title.'</div>';
 						$sourceArrFull = $glosManager->getTaxonSources($tid);
 						$sourceArr = current($sourceArrFull);
@@ -359,7 +309,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 							?>
 							<div style="float:left;margin-left:5px;">
 								<div style="" onclick="toggle('sourcesdiv');return false;">
-									<a href="#"><?php echo (isset($LANG['DISP_SRC'])?$LANG['DISP_SRC']:'(Display Sources)'); ?></a>
+									(<a href="#"><?php echo (isset($LANG['DISP_SRC'])?$LANG['DISP_SRC']:'Display Sources'); ?></a>)
 								</div>
 							</div>
 							<?php
@@ -368,7 +318,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 							if($isEditor){
 								?>
 								<div style="float:left;margin-left:5px;">
-									<a href="sources.php?emode=1&tid=<?php echo $tid.'&searchterm='.$searchTerm.'&language='.$language.'&taxa='.$tid; ?>"><?php echo (isset($LANG['ADD_SRC'])?$LANG['ADD_SRC']:'(Add Sources)'); ?></a>
+									(<a href="sources.php?emode=1&tid=<?php echo $tid.'&searchterm='.$searchTerm.'&language='.$language.'&taxa='.$tid; ?>"><?php echo (isset($LANG['ADD_SRC'])?$LANG['ADD_SRC']:'Add Sources'); ?></a>)
 								</div>
 								<?php
 							}
@@ -378,7 +328,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 					<?php
 					if($sourceArr){
 						?>
-						<div id="sourcesdiv" style="clear:both;display:none;padding:5px">
+						<div id="sourcesdiv" style="display:none;padding:5px">
 							<fieldset style="margin:15px;padding:20px;">
 								<legend><b><?php echo (isset($LANG['TAX_CONTR'])?$LANG['TAX_CONTR']:'Contributors for Taxonomic Group'); ?></b></legend>
 								<?php
@@ -422,7 +372,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 						</div>
 						<?php
 					}
-					echo '<div style="clear:both;padding:10px;"><ul>';
+					echo '<div style="padding:10px;"><ul>';
 					foreach($termList as $glossId => $termName){
 						echo '<li>';
 						echo '<a href="#" onclick="openTermPopup('.$glossId.'); return false;"><b>'.$termName.'</b></a>';
@@ -431,7 +381,7 @@ $taxonName = ($tid?$taxaArr[$tid]:'');
 					echo '</ul></div>';
 				}
 				elseif($formSubmit){
-					echo '<div style="margin-top:10px;font-weight:bold;font-size:120%;">'.(isset($LANG['NO_TERMS'])?$LANG['NO_TERMS']:'There are no terms matching your criteria').'</div>';
+					echo '<div style="margin-top:10px;font-weight:bold;font-size:120%;">'.$LANG['NO_TERMS'].'</div>';
 				}
 				?>
 			</div>

--- a/glossary/individual.php
+++ b/glossary/individual.php
@@ -212,14 +212,15 @@ if($glossId){
 									<?php
 									$imgWidth = 0;
 									$imgHeight = 0;
-									$size = getimagesize(str_replace(' ', '%20', $imgUrl));
-									if($size[0] > 240){
-										$imgWidth = 240;
-										$imgHeight = 0;
-									}
-									if($size[0] < 245 && $size[1] > 500){
-										$imgWidth = 0;
-										$imgHeight = 500;
+									if($size = getimagesize(str_replace(' ', '%20', $imgUrl))){
+										if($size[0] > 240){
+											$imgWidth = 240;
+											$imgHeight = 0;
+										}
+										if($size[0] < 245 && $size[1] > 500){
+											$imgWidth = 0;
+											$imgHeight = 500;
+										}
 									}
 									?>
 									<img src='<?php echo $imgUrl; ?>' style="margin:auto;display:block;border:1px;<?php echo ($imgWidth?'width:'.$imgWidth.'px;':'').($imgHeight?'height:'.$imgHeight.'px;':''); ?>" title='<?php echo $imgArr['structures']; ?>'/>

--- a/js/symb/collections.editor.main.js
+++ b/js/symb/collections.editor.main.js
@@ -1010,38 +1010,32 @@ function eventDateChanged(eventDateInput){
 			if(dateArr['y'] > 0) distributeEventDate(dateArr['y'],dateArr['m'],dateArr['d']);
 		}
 	}
+	else{
+		distributeEventDate("","","");
+	}
 	fieldChanged('eventdate');
-	var f = eventDateInput.form;
-	if(!eventDateInput.form.recordnumber.value && f.recordedby.value) autoDupeSearch();
+	if(!eventDateInput.form.recordnumber.value && eventDateInput.form.recordedby.value) autoDupeSearch();
 	return true;
 }
 
-function distributeEventDate(y,m,d){
+function distributeEventDate(y, m, d){
 	var f = document.fullform;
-	if(y != "0000"){
-		f.year.value = y;
-		fieldChanged("year");
-	}
-	if(m == "00"){
-		f.month.value = "";
-	}
-	else{
-		f.month.value = m;
-		fieldChanged("year");
-	}
-	if(d == "00"){
-		f.day.value = "";
-	}
-	else{
-		f.day.value = d;
-		fieldChanged("day");
-	}
+	if(y == "0000") y = "";
+	f.year.value = y;
+	fieldChanged("year");
+
+	if(m == "00") m = "";
+	f.month.value = m;
+	fieldChanged("month");
+
+	if(d == "00") d = "";
+	f.day.value = d;
+	fieldChanged("day");
+
 	f.startdayofyear.value = "";
+	f.enddayofyear.value = "";
 	try{
-		if(m == 0 || d == 0){
-			f.startdayofyear.value = "";
-		}
-		else{
+		if(m > 0 && d > 0){
 			eDate = new Date(y,m-1,d);
 			if(eDate instanceof Date && eDate != "Invalid Date"){
 				var onejan = new Date(y,0,1);


### PR DESCRIPTION
hotfix 2023-07-31

* Glossary issues
- Allow terms search to do a double wildcard search to expand functionality and resolve issue with zero return when html tags (e.g. italic) are included with the terms
- Remove restrictions and unnecessary default actions associated with unset language and taxon terms so that thesaurus better functions as a single language glossaries
- Fix various issues with export of report when there is a single language glossary and/or terms are not linked to specific taxa
- Fix issue report export not including full list when terms have complex language relationships
- Improve file naming and content/layout of Word report export
- Resolve issues with inclusion of all Spanish language translation files
- Include translations for some missed terms

* Occurrence editor
- Fix bug with year, month, day field failing to null when eventDate is nulled out
- allow tidInterpreted value to be transferred when scientific name is added to form via duplicate tool

* Occurrence Search 
- Fix issue with autocomplete failing to return names that contain single or double quotes
- Fix issue taxon name search failing to return correct data when name contains single or double quotes
- Map Search: resolved issue where map recenters in the middle of the ocean when a search returns no coordinates

* Taxonomy issues and bugs
- Taxonomy Utilities: Fix issue interfering import of taxa with hybrid symbol when there is not a space between symbol and name units
- Taxonomy Harvesting: Resolve 'Unranked" taxonRank designations when taxon is a non-accepted genus
- Taxonomy Upload: Minor adjustments needed to support processing of taxa immediately adjacent to kingdom rank

Pull Request Checklist:

- [ ] Features and backlog bugs should be merged into the `Development` branch, **NOT** `master`
- [ ] Hotfixes should be merged into both the `Development` and `master` branches (at the same time).
- [ ] All new text is preferrably internationalized (i.e., no end-user-visible text is hard-coded on the PHP pages)
- [ ] There are no linter errors
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [ ] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [ ] If any files have been reformatted (e.g., by an autoformatter), the reformat is its own, separate commit in the PR
- [ ] Comment which GitHub issue(s), if any does this PR address
- [ ] It is the code author's responsibility to merge their own pull request after it has been approved
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge from the `Development` branch into the master branch, remember to use the **merge** option
- [ ] If the dev team has agreed that this PR represents the last PR going into the Development branch before a tagged release (i.e., before an imminent merge into the master branch), make sure to notify the team and [lock the `Development` branch](https://github.com/BioKIC/Symbiota/settings/branches) to prevent accidental merges while QA takes place

Thanks for contributing and keeping it clean!
